### PR TITLE
Skipping values duplicates & recording autostart capabilities

### DIFF
--- a/config/CDB/schemas/PropertyRecorder.xsd
+++ b/config/CDB/schemas/PropertyRecorder.xsd
@@ -32,6 +32,7 @@
   	<xs:attribute name="max_props" type="xs:int" use="optional"/>
   	<xs:attribute name="checking_period" type="xs:int" use="optional"/>
   	<xs:attribute name="is_include" type="xs:boolean" use="required"/>
+    <xs:attribute name="autostart" type="xs:boolean" use="required"/>
   	<xs:attribute name="component_list" type="xs:string" use="optional"/>	
   	</xs:extension>
     </xs:complexContent>

--- a/src/ctamonitoring/property_recorder/ComponentRecorder.py
+++ b/src/ctamonitoring/property_recorder/ComponentRecorder.py
@@ -254,6 +254,14 @@ class RecorderConfigDecoder(object):
             raise BadCdbRecorderConfig(e, "is_include")
 
         try:
+            if componentCDB.firstChild.getAttribute("autostart") == 'true':
+                recorder_config.autostart = True
+            else:
+                recorder_config.autostart = False
+        except Exception as e:
+            pass
+
+        try:
             componentCDB.firstChild.getAttribute(
                 "component_list")
             recorder_config.set_components(set(

--- a/src/ctamonitoring/property_recorder/backend/mongodb/registry.py
+++ b/src/ctamonitoring/property_recorder/backend/mongodb/registry.py
@@ -158,7 +158,7 @@ class Buffer(ctamonitoring.property_recorder.backend.dummy.registry.Buffer):
     def __init__(self, log, fifo, chunk_size,
                  property_id, log_id, log_col,
                  component_name, property_name,
-                 disable):
+                 disable, skip_unchanged):
         """
         ctor.
 
@@ -188,10 +188,14 @@ class Buffer(ctamonitoring.property_recorder.backend.dummy.registry.Buffer):
         but isn't actually monitored. This will only allow for calling
         Buffer.close().
         @type disable: boolean
+        @param skip_unchanged: Skip recording of multiple values within one chunk, if
+        the values are the same. Optional, default is False
+        @type skip_unchanged: boolean
         """
         log.debug("creating buffer %s/%s" % (component_name, property_name))
         super(Buffer, self).__init__()
         self._log = log
+        self._skip_unchanged = skip_unchanged
         self._fifo = fifo
         self._chunk_size = chunk_size
         self._property_id = property_id
@@ -203,6 +207,7 @@ class Buffer(ctamonitoring.property_recorder.backend.dummy.registry.Buffer):
         self._bin_begin = None
         self._doc = None
         self._canceled = False  # keep this the last line in ctor
+        self._value = None
 
     def add(self, tm, dt):
         """
@@ -222,6 +227,7 @@ class Buffer(ctamonitoring.property_recorder.backend.dummy.registry.Buffer):
             if self._bin_begin is not None and bin_begin != self._bin_begin:
                 if self._doc and self._doc["end"] is not None:
                     self._fifo.add(self._doc)
+                    self._value = None # flush the current value, so that next chunk includes a value again, if add(...) is called in the meanwhile
                 self._bin_begin = None
                 self._doc = None
             if self._bin_begin is None:
@@ -229,7 +235,13 @@ class Buffer(ctamonitoring.property_recorder.backend.dummy.registry.Buffer):
                 self._doc = {"begin": t, "end": None,
                              "values": [],
                              "bin": bin_begin, "pid": self._property_id}
-            self._doc["values"].append({"t": t, "val": dt})
+            is_changed = (self._value is None) or (self._value != dt)
+            if not self._skip_unchanged or is_changed:
+                self._value = dt
+                self._doc["values"].append({"t": t, "val": dt})
+            else:
+                self._log.debug("skipping %s/%s, new value is unchanged, value: %s" %
+                        (self._component_name, self._property_name, str(dt)))
             self._doc["end"] = t
         else:
             self._log.warn("property monitoring for %s/%s is disabled" %
@@ -357,6 +369,7 @@ class Registry(ctamonitoring.property_recorder.backend.dummy.registry.Registry):
                  properties="properties",
                  chunks="chunks",
                  uri="mongodb://localhost",
+                 skip_unchanged=False,
                  chunk_size=timedelta(seconds=60),
                  fifo_size=1000,
                  n_workers=1,
@@ -383,6 +396,9 @@ class Registry(ctamonitoring.property_recorder.backend.dummy.registry.Registry):
         @type chunks: string
         @param uri: mongodb URI. Optional, default is "mongodb://localhost".
         @type uri: string
+        @param skip_unchanged: Skip recording of multiple values within one chunk, if
+        the values are the same. Optional, default is False
+        @type skip_unchanged: boolean
         @param chunk_size: Specifies the time duration within monitoring data
         is safed into a chunk (fraction of seconds will be ignored).
         Optional, default is 1 minute.
@@ -415,6 +431,7 @@ class Registry(ctamonitoring.property_recorder.backend.dummy.registry.Registry):
         self._properties_name = properties
         self._chunks_name = chunks
         self._uri = uri
+        self._skip_unchanged = skip_unchanged
         if isinstance(chunk_size, timedelta):
             self._chunk_size = chunk_size
         else:
@@ -532,7 +549,7 @@ class Registry(ctamonitoring.property_recorder.backend.dummy.registry.Registry):
         return Buffer(self._log, self._fifo, self._chunk_size,
                       property_id, log_id, self._logs,
                       component_name, property_name,
-                      disable)
+                      disable, self._skip_unchanged)
 
     def __del__(self):
         """dtor."""

--- a/src/ctamonitoring/property_recorder/backend/mongodb/registry.py
+++ b/src/ctamonitoring/property_recorder/backend/mongodb/registry.py
@@ -423,6 +423,7 @@ class Registry(ctamonitoring.property_recorder.backend.dummy.registry.Registry):
         @type log: logging.Logger
         """
         super(Registry, self).__init__(log, *args, **kwargs)
+        self._log = log
         if not self._log:
             self._log = getLogger(defaultname)
         self._log.debug("creating a mongodb registry")

--- a/src/ctamonitoring/property_recorder/front_end.py
+++ b/src/ctamonitoring/property_recorder/front_end.py
@@ -116,6 +116,10 @@ class FrontEnd(object):
 
         self._setup_backend()
 
+        if self.recorder_config.autostart:
+            self.logger.logWarning("Starting recording automatically")
+            self.start_recording()
+
         self._start_watchdog()
 
         self._is_acs_client_ok = True

--- a/src/ctamonitoring/property_recorder/standalone_recorder.py
+++ b/src/ctamonitoring/property_recorder/standalone_recorder.py
@@ -348,6 +348,7 @@ class RecorderParser(object):
             recorder_config.is_include_mode = self._args['is_include_mode']
         if 'component_list' in self._args:
             recorder_config.set_components(self._args['component_list'])
+        recorder_config.autostart = False # in standalone mode recording start automatically anyway
 
         return recorder_config
 

--- a/test/CDB/alma/logRecorder/logRecorder.xml
+++ b/test/CDB/alma/logRecorder/logRecorder.xml
@@ -10,6 +10,7 @@
        max_props="500"
        checking_period="30"
        is_include="false"
+       autostart="false"
        component_list="['Component1', 'Component2']">
         <dummy
        />

--- a/test/CDB/alma/mongoRecorder/mongoRecorder.xml
+++ b/test/CDB/alma/mongoRecorder/mongoRecorder.xml
@@ -10,6 +10,7 @@
        max_props="500"
        checking_period="30"
        is_include="false"
+       autostart="false"
        component_list="['Component1', 'Component2']">
         <dummy
        />

--- a/test/CDB/alma/propertyRecorder1/propertyRecorder1.xml
+++ b/test/CDB/alma/propertyRecorder1/propertyRecorder1.xml
@@ -10,6 +10,7 @@
        max_props="500"
        checking_period="30"
        is_include="false"
+       autostart="false"
        component_list="['Component1', 'Component2']">
         <dummy
        />

--- a/test/test_util/CDB/alma/propertyRecorder1/propertyRecorder1.xml
+++ b/test/test_util/CDB/alma/propertyRecorder1/propertyRecorder1.xml
@@ -10,6 +10,7 @@
        max_props="500"
        checking_period="30"
        is_include="false"
+       autostart="false"
        component_list="['Component1', 'Component2']">
         <dummy
        />


### PR DESCRIPTION
Two commits. 
1. Mongodb backend was modified to skip duplicating values within one chunk (can be configured with `skip_unchanged` boolean parameter in the backend configuration). I.e. if the property callback pushes the same value, then the chunk will include 'values' record with only one item.

2. Adding possibility to start recording right after ACS component is being activated. Configured with `autostart` boolean parameter within the CDB.
